### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for [F
 
 <img width="2060" alt="mcp" src="https://github.com/user-attachments/assets/cc32a6dd-5368-43c1-897a-a0ccfeeacaf0" />
 
+<a href="https://glama.ai/mcp/servers/@flipt-io/mcp-server-flipt">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@flipt-io/mcp-server-flipt/badge" alt="Flipt Server MCP server" />
+</a>
+
 ## Features
 
 - List, create, update, and delete namespaces, flags, segments, rules, and more


### PR DESCRIPTION
This PR adds a badge for the [Flipt MCP Server](https://glama.ai/mcp/servers/@flipt-io/mcp-server-flipt) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@flipt-io/mcp-server-flipt">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@flipt-io/mcp-server-flipt/badge" alt="Flipt Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.